### PR TITLE
Remove references to the old `open-term-by-default` var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ nvimux.config.set_all{
   new_window_buffer = 'single',
   quickterm_direction = 'botright',
   quickterm_orientation = 'vertical',
-  -- Use 'g' for global quickterm
-  quickterm_scope = 't',
+  quickterm_scope = 't', -- Use 'g' for global quickterm
   quickterm_size = '80',
 }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ local nvimux = require('nvimux')
 -- Nvimux configuration
 nvimux.config.set_all{
   prefix = '<C-a>',
-  open_term_by_default = true,
+  new_window = 'enew', -- Use 'term' if you want to open a new term for every new window
+  new_tab = nil, -- Defaults to new_window. Set to 'term' if you want a new term for every new tab
   new_window_buffer = 'single',
   quickterm_direction = 'botright',
   quickterm_orientation = 'vertical',

--- a/lua/nvimux.lua
+++ b/lua/nvimux.lua
@@ -40,7 +40,7 @@ local vars = {
   quickterm_direction = 'botright',
   quickterm_orientation = 'vertical',
   quickterm_size = '',
-  new_term = 'term',
+  quickterm_command = 'term',
   close_term = ':x',
   new_window = 'enew',
   new_tab = nil
@@ -226,7 +226,7 @@ end
 -- [[ Quickterm
 nvimux.term.new_toggle = function()
   local split_type = vars:split_type()
-  nvim.nvim_command(split_type .. ' | enew | ' .. vars.new_term)
+  nvim.nvim_command(split_type .. ' | enew | ' .. vars.quickterm_command)
   local buf_nr = nvim.nvim_call_function('bufnr', {'%'})
   nvim.nvim_set_option('wfw', true)
   fns.variables.set{mode='b', nr=buf_nr, name='nvimux_buf_orientation', value=split_type}

--- a/lua/nvimux.lua
+++ b/lua/nvimux.lua
@@ -42,7 +42,8 @@ local vars = {
   quickterm_size = '',
   new_term = 'term',
   close_term = ':x',
-  new_window = 'enew'
+  new_window = 'enew',
+  new_tab = nil
 }
 
 vars.split_type = function(t)
@@ -81,7 +82,7 @@ local bindings = {
 local nvimux_commands = {
   {name = 'NvimuxHorizontalSplit', lazy_cmd = function() return [[spl|wincmd j|]] .. vars.new_window end},
   {name = 'NvimuxVerticalSplit', lazy_cmd = function() return [[vspl|wincmd l|]] .. vars.new_window end},
-  {name = 'NvimuxNewTab', lazy_cmd = function() return [[tabe|]] .. vars.new_window end},
+  {name = 'NvimuxNewTab', lazy_cmd = function() return [[tabe|]] .. vars.new_tab or vars.new_window end},
   {name = 'NvimuxSet', cmd = [[lua require('nvimux').config.set_fargs(<f-args>)]], nargs='+'},
 }
 


### PR DESCRIPTION
Additionally, add a variable for controlling new tabs sepparately from new windows.

This should fix #25

The new way of setting a new tab to open a term is by setting:
```vim
lua << EOF
local nvimux = require("nvimux")

nvimux.config.set_all{
  -- ...
  new_tab = "term",
  -- ...
}

-- ...

nvimux.bootstrap()
```